### PR TITLE
Reduce default metric label cardinality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ The `promgithub` service is a lightweight service designed to receive and proces
 
 The `promgithub` service exports the following Prometheus metrics:
 
-| Name                               | Type      | Labels                                                                                         | Description                               |
-|------------------------------------|-----------|------------------------------------------------------------------------------------------------|-------------------------------------------|
-| `promgithub_workflow_status`       | Counter   | `repository`, `branch`, `workflow_name`, `workflow_status`, `conclusion`                       | Total number of workflow runs with status |
-| `promgithub_workflow_duration`     | Histogram | `repository`, `branch`, `workflow_name`, `workflow_status`, `conclusion`                       | Duration of workflow runs                 |
-| `promgithub_workflow_queued`       | Gauge     | `repository`, `branch`, `workflow_name`                                                        | Number of workflow runs queued            |
-| `promgithub_workflow_in_progress`  | Gauge     | `repository`, `branch`, `workflow_name`                                                        | Number of workflow runs in progress       |
-| `promgithub_workflow_completed`    | Gauge     | `repository`, `branch`, `workflow_conclusion`,`workflow_name`                                  | Number of workflow runs completed         |
-| `promgithub_job_status`            | Counter   | `runner`, `repository`, `branch`, `workflow_name`, `job_name`, `job_status`, `job_conclusion`, | Total number of jobs with status          |
-| `promgithub_job_duration`          | Histogram | `runner`, `repository`, `branch`, `workflow_name`, `job_name`, `job_status`, `job_conclusion`  | Duration of jobs runs in seconds          |
-| `promgithub_job_queued`            | Gauge     | `runner`, `repository`, `branch`, `workflow_name`, `job_name`                                  | Number of jobs queued                     |
-| `promgithub_job_in_progress`       | Gauge     | `runner`, `repository`, `branch`, `workflow_name`, `job_name`                                  | Number of jobs in progress                |
-| `promgithub_job_completed`         | Gauge     | `runner`, `repository`, `branch`, `job_conclusion`, `workflow_name`, `job_name`                | Number of jobs completed                  |
-| `promgithub_commit_pushed`         | Counter   | `repository`, `branch`, `commit_author`, `commit_author_email`                                 | Total number of commits pushed            |
-| `promgithub_pull_request`          | Counter   | `repository`, `base_branch`, `pull_request_author`, `pull_request_status`                      | Total number of pull requests             |
+| Name                               | Type      | Labels                                                        | Description                               |
+|------------------------------------|-----------|---------------------------------------------------------------|-------------------------------------------|
+| `promgithub_workflow_status`       | Counter   | `repository`, `workflow_name`, `workflow_status`, `conclusion`| Total number of workflow runs with status |
+| `promgithub_workflow_duration`     | Histogram | `repository`, `workflow_name`, `workflow_status`, `conclusion`| Duration of workflow runs                 |
+| `promgithub_workflow_queued`       | Gauge     | `repository`, `workflow_name`                                 | Number of workflow runs queued            |
+| `promgithub_workflow_in_progress`  | Gauge     | `repository`, `workflow_name`                                 | Number of workflow runs in progress       |
+| `promgithub_workflow_completed`    | Gauge     | `repository`, `workflow_conclusion`,`workflow_name`           | Number of workflow runs completed         |
+| `promgithub_job_status`            | Counter   | `repository`, `workflow_name`, `job_status`, `job_conclusion` | Total number of jobs with status          |
+| `promgithub_job_duration`          | Histogram | `repository`, `workflow_name`, `job_status`, `job_conclusion` | Duration of jobs runs in seconds          |
+| `promgithub_job_queued`            | Gauge     | `repository`, `workflow_name`                                 | Number of jobs queued                     |
+| `promgithub_job_in_progress`       | Gauge     | `repository`, `workflow_name`                                 | Number of jobs in progress                |
+| `promgithub_job_completed`         | Gauge     | `repository`, `job_conclusion`, `workflow_name`               | Number of jobs completed                  |
+| `promgithub_commit_pushed`         | Counter   | `repository`                                                  | Total number of commits pushed            |
+| `promgithub_pull_request`          | Counter   | `repository`, `base_branch`, `pull_request_status`            | Total number of pull requests             |
+
 
 ## Using `promgithub` service
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ The `promgithub` service exports the following Prometheus metrics:
 
 | Name                               | Type      | Labels                                                        | Description                               |
 |------------------------------------|-----------|---------------------------------------------------------------|-------------------------------------------|
-| `promgithub_workflow_status`       | Counter   | `repository`, `workflow_name`, `workflow_status`, `conclusion`| Total number of workflow runs with status |
-| `promgithub_workflow_duration`     | Histogram | `repository`, `workflow_name`, `workflow_status`, `conclusion`| Duration of workflow runs                 |
-| `promgithub_workflow_queued`       | Gauge     | `repository`, `workflow_name`                                 | Number of workflow runs queued            |
-| `promgithub_workflow_in_progress`  | Gauge     | `repository`, `workflow_name`                                 | Number of workflow runs in progress       |
-| `promgithub_workflow_completed`    | Gauge     | `repository`, `workflow_conclusion`,`workflow_name`           | Number of workflow runs completed         |
-| `promgithub_job_status`            | Counter   | `repository`, `workflow_name`, `job_status`, `job_conclusion` | Total number of jobs with status          |
-| `promgithub_job_duration`          | Histogram | `repository`, `workflow_name`, `job_status`, `job_conclusion` | Duration of jobs runs in seconds          |
-| `promgithub_job_queued`            | Gauge     | `repository`, `workflow_name`                                 | Number of jobs queued                     |
-| `promgithub_job_in_progress`       | Gauge     | `repository`, `workflow_name`                                 | Number of jobs in progress                |
-| `promgithub_job_completed`         | Gauge     | `repository`, `job_conclusion`, `workflow_name`               | Number of jobs completed                  |
+| `promgithub_workflow_status`       | Counter   | `repository`, `branch`, `workflow_name`, `workflow_status`, `conclusion`| Total number of workflow runs with status |
+| `promgithub_workflow_duration`     | Histogram | `repository`, `branch`, `workflow_name`, `workflow_status`, `conclusion`| Duration of workflow runs                 |
+| `promgithub_workflow_queued`       | Gauge     | `repository`, `branch`, `workflow_name`                       | Number of workflow runs queued            |
+| `promgithub_workflow_in_progress`  | Gauge     | `repository`, `branch`, `workflow_name`                       | Number of workflow runs in progress       |
+| `promgithub_workflow_completed`    | Gauge     | `repository`, `branch`, `workflow_conclusion`,`workflow_name` | Number of workflow runs completed         |
+| `promgithub_job_status`            | Counter   | `repository`, `branch`, `workflow_name`, `job_status`, `job_conclusion` | Total number of jobs with status          |
+| `promgithub_job_duration`          | Histogram | `repository`, `branch`, `workflow_name`, `job_status`, `job_conclusion` | Duration of jobs runs in seconds          |
+| `promgithub_job_queued`            | Gauge     | `repository`, `branch`, `workflow_name`                       | Number of jobs queued                     |
+| `promgithub_job_in_progress`       | Gauge     | `repository`, `branch`, `workflow_name`                       | Number of jobs in progress                |
+| `promgithub_job_completed`         | Gauge     | `repository`, `branch`, `job_conclusion`, `workflow_name`     | Number of jobs completed                  |
 | `promgithub_commit_pushed`         | Counter   | `repository`                                                  | Total number of commits pushed            |
 | `promgithub_pull_request`          | Counter   | `repository`, `base_branch`, `pull_request_status`            | Total number of pull requests             |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,7 +123,25 @@ PROMGITHUB_WEBHOOK_SECRET="<your webhook secret>" PROMGITHUB_SERVICE_PORT="<serv
 
 ## Prometheus scraping configuration
 
-Configure prometheus to scrape `promgithub`'s `/metrics` endpoint to extract metrics
+Configure prometheus to scrape `promgithub`'s `/metrics` endpoint to extract metrics.
+
+## Metric label defaults and upgrade notes
+
+`promgithub` now ships with lower-cardinality default labels to make Prometheus usage safer in larger repositories and organizations.
+
+The following labels are no longer exported by default:
+- workflow/job `branch`
+- job `runner`
+- job `job_name`
+- push `commit_author`
+- push `commit_author_email`
+- pull request `pull_request_author`
+
+This change reduces unbounded series growth from ephemeral branches, runners, and author-identifying fields.
+
+If you are upgrading an existing deployment, update any dashboards, alerts, or recording rules that reference the removed labels before rolling out the new version.
+
+Configure prometheus to scrape `promgithub`'s `/metrics` endpoint to extract metrics.
 
 ### Prometheus configuration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,24 +125,6 @@ PROMGITHUB_WEBHOOK_SECRET="<your webhook secret>" PROMGITHUB_SERVICE_PORT="<serv
 
 Configure prometheus to scrape `promgithub`'s `/metrics` endpoint to extract metrics.
 
-## Metric label defaults and upgrade notes
-
-`promgithub` now ships with lower-cardinality default labels to make Prometheus usage safer in larger repositories and organizations.
-
-The following labels are no longer exported by default:
-- workflow/job `branch`
-- job `runner`
-- job `job_name`
-- push `commit_author`
-- push `commit_author_email`
-- pull request `pull_request_author`
-
-This change reduces unbounded series growth from ephemeral branches, runners, and author-identifying fields.
-
-If you are upgrading an existing deployment, update any dashboards, alerts, or recording rules that reference the removed labels before rolling out the new version.
-
-Configure prometheus to scrape `promgithub`'s `/metrics` endpoint to extract metrics.
-
 ### Prometheus configuration
 
 To allow prometheus to scrape `promgithub`'s `/metrics` endpoint, add the following configuration to your prometheus setup:

--- a/src/github.go
+++ b/src/github.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -129,58 +128,49 @@ func updateWorkflowMetrics(body []byte) {
 		return
 	}
 
-	workflowStatusCounter.With(prometheus.Labels{
-		"repository":      payload.Workflow.Repository.FullName,
-		"branch":          payload.Workflow.Branch,
-		"workflow_name":   payload.Workflow.Name,
-		"workflow_status": payload.Workflow.Status,
-		"conclusion":      payload.Workflow.Conclusion,
-	}).Inc()
+	workflowStatusCounter.WithLabelValues(
+		payload.Workflow.Repository.FullName,
+		payload.Workflow.Name,
+		payload.Workflow.Status,
+		payload.Workflow.Conclusion,
+	).Inc()
 
-	// Handle updating the gauges based on workflow status
 	switch strings.ToLower(payload.Workflow.Status) {
 	case "queued":
-		workflowQueuedGauge.With(prometheus.Labels{
-			"repository":    payload.Workflow.Repository.FullName,
-			"branch":        payload.Workflow.Branch,
-			"workflow_name": payload.Workflow.Name,
-		}).Inc()
+		workflowQueuedGauge.WithLabelValues(
+			payload.Workflow.Repository.FullName,
+			payload.Workflow.Name,
+		).Inc()
 	case "in_progress":
-		workflowInProgressGauge.With(prometheus.Labels{
-			"repository":    payload.Workflow.Repository.FullName,
-			"branch":        payload.Workflow.Branch,
-			"workflow_name": payload.Workflow.Name,
-		}).Inc()
-		workflowQueuedGauge.With(prometheus.Labels{
-			"repository":    payload.Workflow.Repository.FullName,
-			"branch":        payload.Workflow.Branch,
-			"workflow_name": payload.Workflow.Name,
-		}).Dec()
+		workflowInProgressGauge.WithLabelValues(
+			payload.Workflow.Repository.FullName,
+			payload.Workflow.Name,
+		).Inc()
+		workflowQueuedGauge.WithLabelValues(
+			payload.Workflow.Repository.FullName,
+			payload.Workflow.Name,
+		).Dec()
 	case "completed":
-		workflowCompletedGauge.With(prometheus.Labels{
-			"repository":          payload.Workflow.Repository.FullName,
-			"branch":              payload.Workflow.Branch,
-			"workflow_conclusion": payload.Workflow.Conclusion,
-			"workflow_name":       payload.Workflow.Name,
-		}).Inc()
-		workflowInProgressGauge.With(prometheus.Labels{
-			"repository":    payload.Workflow.Repository.FullName,
-			"branch":        payload.Workflow.Branch,
-			"workflow_name": payload.Workflow.Name,
-		}).Dec()
+		workflowCompletedGauge.WithLabelValues(
+			payload.Workflow.Repository.FullName,
+			payload.Workflow.Conclusion,
+			payload.Workflow.Name,
+		).Inc()
+		workflowInProgressGauge.WithLabelValues(
+			payload.Workflow.Repository.FullName,
+			payload.Workflow.Name,
+		).Dec()
 
-		// Update duration histogram when the workflow is completed
 		createdAt, err1 := time.Parse(time.RFC3339, payload.Workflow.CreatedAt)
 		updatedAt, err2 := time.Parse(time.RFC3339, payload.Workflow.UpdatedAt)
 		if err1 == nil && err2 == nil {
 			duration := updatedAt.Sub(createdAt).Seconds()
-			workflowDurationHistogram.With(prometheus.Labels{
-				"repository":      payload.Workflow.Repository.FullName,
-				"branch":          payload.Workflow.Branch,
-				"workflow_name":   payload.Workflow.Name,
-				"workflow_status": payload.Workflow.Status,
-				"conclusion":      payload.Workflow.Conclusion,
-			}).Observe(duration)
+			workflowDurationHistogram.WithLabelValues(
+				payload.Workflow.Repository.FullName,
+				payload.Workflow.Name,
+				payload.Workflow.Status,
+				payload.Workflow.Conclusion,
+			).Observe(duration)
 		}
 	}
 }
@@ -193,72 +183,49 @@ func updateJobMetrics(body []byte) {
 		return
 	}
 
-	jobStatusCounter.With(prometheus.Labels{
-		"runner":         payload.Job.RunnerName,
-		"repository":     payload.Job.Repository.FullName,
-		"branch":         payload.Job.Branch,
-		"workflow_name":  payload.Job.WorkflowName,
-		"job_name":       payload.Job.Name,
-		"job_status":     payload.Job.Status,
-		"job_conclusion": payload.Job.Conclusion,
-	}).Inc()
+	jobStatusCounter.WithLabelValues(
+		payload.Job.Repository.FullName,
+		payload.Job.WorkflowName,
+		payload.Job.Status,
+		payload.Job.Conclusion,
+	).Inc()
 
-	// Handle updating the gauges based on job status
 	switch strings.ToLower(payload.Job.Status) {
 	case "queued":
-		jobQueuedGauge.With(prometheus.Labels{
-			"runner":        payload.Job.RunnerName,
-			"repository":    payload.Job.Repository.FullName,
-			"branch":        payload.Job.Branch,
-			"workflow_name": payload.Job.WorkflowName,
-			"job_name":      payload.Job.Name,
-		}).Inc()
+		jobQueuedGauge.WithLabelValues(
+			payload.Job.Repository.FullName,
+			payload.Job.WorkflowName,
+		).Inc()
 	case "in_progress":
-		jobInProgressGauge.With(prometheus.Labels{
-			"runner":        payload.Job.RunnerName,
-			"repository":    payload.Job.Repository.FullName,
-			"branch":        payload.Job.Branch,
-			"workflow_name": payload.Job.WorkflowName,
-			"job_name":      payload.Job.Name,
-		}).Inc()
-		jobQueuedGauge.With(prometheus.Labels{
-			"runner":        payload.Job.RunnerName,
-			"repository":    payload.Job.Repository.FullName,
-			"branch":        payload.Job.Branch,
-			"workflow_name": payload.Job.WorkflowName,
-			"job_name":      payload.Job.Name,
-		}).Dec()
+		jobInProgressGauge.WithLabelValues(
+			payload.Job.Repository.FullName,
+			payload.Job.WorkflowName,
+		).Inc()
+		jobQueuedGauge.WithLabelValues(
+			payload.Job.Repository.FullName,
+			payload.Job.WorkflowName,
+		).Dec()
 	case "completed":
-		jobCompletedGauge.With(prometheus.Labels{
-			"runner":         payload.Job.RunnerName,
-			"repository":     payload.Job.Repository.FullName,
-			"branch":         payload.Job.Branch,
-			"job_conclusion": payload.Job.Conclusion,
-			"workflow_name":  payload.Job.WorkflowName,
-			"job_name":       payload.Job.Name,
-		}).Inc()
-		jobInProgressGauge.With(prometheus.Labels{
-			"runner":        payload.Job.RunnerName,
-			"repository":    payload.Job.Repository.FullName,
-			"branch":        payload.Job.Branch,
-			"workflow_name": payload.Job.WorkflowName,
-			"job_name":      payload.Job.Name,
-		}).Dec()
+		jobCompletedGauge.WithLabelValues(
+			payload.Job.Repository.FullName,
+			payload.Job.Conclusion,
+			payload.Job.WorkflowName,
+		).Inc()
+		jobInProgressGauge.WithLabelValues(
+			payload.Job.Repository.FullName,
+			payload.Job.WorkflowName,
+		).Dec()
 
-		// Update duration histogram when the job is completed
 		startedAt, err1 := time.Parse(time.RFC3339, payload.Job.StartedAt)
 		completedAt, err2 := time.Parse(time.RFC3339, payload.Job.CompletedAt)
 		if err1 == nil && err2 == nil {
 			duration := completedAt.Sub(startedAt).Seconds()
-			jobDurationHistogram.With(prometheus.Labels{
-				"runner":         payload.Job.RunnerName,
-				"repository":     payload.Job.Repository.FullName,
-				"branch":         payload.Job.Branch,
-				"workflow_name":  payload.Job.WorkflowName,
-				"job_name":       payload.Job.Name,
-				"job_status":     payload.Job.Status,
-				"job_conclusion": payload.Job.Conclusion,
-			}).Observe(duration)
+			jobDurationHistogram.WithLabelValues(
+				payload.Job.Repository.FullName,
+				payload.Job.WorkflowName,
+				payload.Job.Status,
+				payload.Job.Conclusion,
+			).Observe(duration)
 		}
 	}
 }
@@ -271,13 +238,8 @@ func updateCommitMetrics(body []byte) {
 		return
 	}
 
-	for _, commit := range payload.Commits {
-		commitPushedCounter.With(prometheus.Labels{
-			"repository":          payload.Repository.FullName,
-			"branch":              payload.Ref,
-			"commit_author":       commit.Author.Name,
-			"commit_author_email": commit.Author.Email,
-		}).Inc()
+	for range payload.Commits {
+		commitPushedCounter.WithLabelValues(payload.Repository.FullName).Inc()
 	}
 }
 
@@ -289,10 +251,9 @@ func updatePullRequestMetrics(body []byte) {
 		return
 	}
 
-	pullRequestCounter.With(prometheus.Labels{
-		"repository":          payload.Repository.FullName,
-		"base_branch":         payload.PullRequest.Base.Ref,
-		"pull_request_author": payload.PullRequest.User.Login,
-		"pull_request_status": payload.Action,
-	}).Inc()
+	pullRequestCounter.WithLabelValues(
+		payload.Repository.FullName,
+		payload.PullRequest.Base.Ref,
+		payload.Action,
+	).Inc()
 }

--- a/src/github.go
+++ b/src/github.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -81,6 +82,15 @@ type GithubPullRequest struct {
 	Repository GithubRepo `json:"repository"`
 }
 
+type runMetricDetails struct {
+	repository string
+	name       string
+	status     string
+	conclusion string
+	startedAt  string
+	endedAt    string
+}
+
 func validateHMAC(body []byte, signature string, secret []byte) bool {
 	h := hmac.New(sha256.New, secret)
 	h.Write(body)
@@ -120,6 +130,61 @@ func githubEventsHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func observeRunMetrics(
+	details runMetricDetails,
+	statusCounter *prometheus.CounterVec,
+	queuedGauge *prometheus.GaugeVec,
+	inProgressGauge *prometheus.GaugeVec,
+	completedGauge *prometheus.GaugeVec,
+	durationHistogram *prometheus.HistogramVec,
+) {
+	statusCounter.WithLabelValues(
+		details.repository,
+		details.name,
+		details.status,
+		details.conclusion,
+	).Inc()
+
+	switch strings.ToLower(details.status) {
+	case "queued":
+		queuedGauge.WithLabelValues(
+			details.repository,
+			details.name,
+		).Inc()
+	case "in_progress":
+		inProgressGauge.WithLabelValues(
+			details.repository,
+			details.name,
+		).Inc()
+		queuedGauge.WithLabelValues(
+			details.repository,
+			details.name,
+		).Dec()
+	case "completed":
+		completedGauge.WithLabelValues(
+			details.repository,
+			details.conclusion,
+			details.name,
+		).Inc()
+		inProgressGauge.WithLabelValues(
+			details.repository,
+			details.name,
+		).Dec()
+
+		startedAt, err1 := time.Parse(time.RFC3339, details.startedAt)
+		endedAt, err2 := time.Parse(time.RFC3339, details.endedAt)
+		if err1 == nil && err2 == nil {
+			duration := endedAt.Sub(startedAt).Seconds()
+			durationHistogram.WithLabelValues(
+				details.repository,
+				details.name,
+				details.status,
+				details.conclusion,
+			).Observe(duration)
+		}
+	}
+}
+
 func updateWorkflowMetrics(body []byte) {
 	var payload GithubWorkflow
 
@@ -128,51 +193,21 @@ func updateWorkflowMetrics(body []byte) {
 		return
 	}
 
-	workflowStatusCounter.WithLabelValues(
-		payload.Workflow.Repository.FullName,
-		payload.Workflow.Name,
-		payload.Workflow.Status,
-		payload.Workflow.Conclusion,
-	).Inc()
-
-	switch strings.ToLower(payload.Workflow.Status) {
-	case "queued":
-		workflowQueuedGauge.WithLabelValues(
-			payload.Workflow.Repository.FullName,
-			payload.Workflow.Name,
-		).Inc()
-	case "in_progress":
-		workflowInProgressGauge.WithLabelValues(
-			payload.Workflow.Repository.FullName,
-			payload.Workflow.Name,
-		).Inc()
-		workflowQueuedGauge.WithLabelValues(
-			payload.Workflow.Repository.FullName,
-			payload.Workflow.Name,
-		).Dec()
-	case "completed":
-		workflowCompletedGauge.WithLabelValues(
-			payload.Workflow.Repository.FullName,
-			payload.Workflow.Conclusion,
-			payload.Workflow.Name,
-		).Inc()
-		workflowInProgressGauge.WithLabelValues(
-			payload.Workflow.Repository.FullName,
-			payload.Workflow.Name,
-		).Dec()
-
-		createdAt, err1 := time.Parse(time.RFC3339, payload.Workflow.CreatedAt)
-		updatedAt, err2 := time.Parse(time.RFC3339, payload.Workflow.UpdatedAt)
-		if err1 == nil && err2 == nil {
-			duration := updatedAt.Sub(createdAt).Seconds()
-			workflowDurationHistogram.WithLabelValues(
-				payload.Workflow.Repository.FullName,
-				payload.Workflow.Name,
-				payload.Workflow.Status,
-				payload.Workflow.Conclusion,
-			).Observe(duration)
-		}
-	}
+	observeRunMetrics(
+		runMetricDetails{
+			repository: payload.Workflow.Repository.FullName,
+			name:       payload.Workflow.Name,
+			status:     payload.Workflow.Status,
+			conclusion: payload.Workflow.Conclusion,
+			startedAt:  payload.Workflow.CreatedAt,
+			endedAt:    payload.Workflow.UpdatedAt,
+		},
+		workflowStatusCounter,
+		workflowQueuedGauge,
+		workflowInProgressGauge,
+		workflowCompletedGauge,
+		workflowDurationHistogram,
+	)
 }
 
 func updateJobMetrics(body []byte) {
@@ -183,51 +218,21 @@ func updateJobMetrics(body []byte) {
 		return
 	}
 
-	jobStatusCounter.WithLabelValues(
-		payload.Job.Repository.FullName,
-		payload.Job.WorkflowName,
-		payload.Job.Status,
-		payload.Job.Conclusion,
-	).Inc()
-
-	switch strings.ToLower(payload.Job.Status) {
-	case "queued":
-		jobQueuedGauge.WithLabelValues(
-			payload.Job.Repository.FullName,
-			payload.Job.WorkflowName,
-		).Inc()
-	case "in_progress":
-		jobInProgressGauge.WithLabelValues(
-			payload.Job.Repository.FullName,
-			payload.Job.WorkflowName,
-		).Inc()
-		jobQueuedGauge.WithLabelValues(
-			payload.Job.Repository.FullName,
-			payload.Job.WorkflowName,
-		).Dec()
-	case "completed":
-		jobCompletedGauge.WithLabelValues(
-			payload.Job.Repository.FullName,
-			payload.Job.Conclusion,
-			payload.Job.WorkflowName,
-		).Inc()
-		jobInProgressGauge.WithLabelValues(
-			payload.Job.Repository.FullName,
-			payload.Job.WorkflowName,
-		).Dec()
-
-		startedAt, err1 := time.Parse(time.RFC3339, payload.Job.StartedAt)
-		completedAt, err2 := time.Parse(time.RFC3339, payload.Job.CompletedAt)
-		if err1 == nil && err2 == nil {
-			duration := completedAt.Sub(startedAt).Seconds()
-			jobDurationHistogram.WithLabelValues(
-				payload.Job.Repository.FullName,
-				payload.Job.WorkflowName,
-				payload.Job.Status,
-				payload.Job.Conclusion,
-			).Observe(duration)
-		}
-	}
+	observeRunMetrics(
+		runMetricDetails{
+			repository: payload.Job.Repository.FullName,
+			name:       payload.Job.WorkflowName,
+			status:     payload.Job.Status,
+			conclusion: payload.Job.Conclusion,
+			startedAt:  payload.Job.StartedAt,
+			endedAt:    payload.Job.CompletedAt,
+		},
+		jobStatusCounter,
+		jobQueuedGauge,
+		jobInProgressGauge,
+		jobCompletedGauge,
+		jobDurationHistogram,
+	)
 }
 
 func updateCommitMetrics(body []byte) {

--- a/src/github.go
+++ b/src/github.go
@@ -84,6 +84,7 @@ type GithubPullRequest struct {
 
 type runMetricDetails struct {
 	repository string
+	branch     string
 	name       string
 	status     string
 	conclusion string
@@ -140,6 +141,7 @@ func observeRunMetrics(
 ) {
 	statusCounter.WithLabelValues(
 		details.repository,
+		details.branch,
 		details.name,
 		details.status,
 		details.conclusion,
@@ -149,25 +151,30 @@ func observeRunMetrics(
 	case "queued":
 		queuedGauge.WithLabelValues(
 			details.repository,
+			details.branch,
 			details.name,
 		).Inc()
 	case "in_progress":
 		inProgressGauge.WithLabelValues(
 			details.repository,
+			details.branch,
 			details.name,
 		).Inc()
 		queuedGauge.WithLabelValues(
 			details.repository,
+			details.branch,
 			details.name,
 		).Dec()
 	case "completed":
 		completedGauge.WithLabelValues(
 			details.repository,
+			details.branch,
 			details.conclusion,
 			details.name,
 		).Inc()
 		inProgressGauge.WithLabelValues(
 			details.repository,
+			details.branch,
 			details.name,
 		).Dec()
 
@@ -177,6 +184,7 @@ func observeRunMetrics(
 			duration := endedAt.Sub(startedAt).Seconds()
 			durationHistogram.WithLabelValues(
 				details.repository,
+				details.branch,
 				details.name,
 				details.status,
 				details.conclusion,
@@ -196,6 +204,7 @@ func updateWorkflowMetrics(body []byte) {
 	observeRunMetrics(
 		runMetricDetails{
 			repository: payload.Workflow.Repository.FullName,
+			branch:     payload.Workflow.Branch,
 			name:       payload.Workflow.Name,
 			status:     payload.Workflow.Status,
 			conclusion: payload.Workflow.Conclusion,
@@ -221,6 +230,7 @@ func updateJobMetrics(body []byte) {
 	observeRunMetrics(
 		runMetricDetails{
 			repository: payload.Job.Repository.FullName,
+			branch:     payload.Job.Branch,
 			name:       payload.Job.WorkflowName,
 			status:     payload.Job.Status,
 			conclusion: payload.Job.Conclusion,

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -12,7 +12,7 @@ var (
 			Name: "promgithub_workflow_status",
 			Help: "Total number of workflow runs with status",
 		},
-		[]string{"repository", "workflow_name", "workflow_status", "conclusion"},
+		[]string{"repository", "branch", "workflow_name", "workflow_status", "conclusion"},
 	)
 
 	workflowDurationHistogram = promauto.NewHistogramVec(
@@ -21,7 +21,7 @@ var (
 			Help:    "Duration of workflow runs",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"repository", "workflow_name", "workflow_status", "conclusion"},
+		[]string{"repository", "branch", "workflow_name", "workflow_status", "conclusion"},
 	)
 
 	workflowQueuedGauge = promauto.NewGaugeVec(
@@ -29,7 +29,7 @@ var (
 			Name: "promgithub_workflow_queued",
 			Help: "Number of workflow runs queued",
 		},
-		[]string{"repository", "workflow_name"},
+		[]string{"repository", "branch", "workflow_name"},
 	)
 
 	workflowInProgressGauge = promauto.NewGaugeVec(
@@ -37,7 +37,7 @@ var (
 			Name: "promgithub_workflow_in_progress",
 			Help: "Number of workflow runs in progress",
 		},
-		[]string{"repository", "workflow_name"},
+		[]string{"repository", "branch", "workflow_name"},
 	)
 
 	workflowCompletedGauge = promauto.NewGaugeVec(
@@ -45,7 +45,7 @@ var (
 			Name: "promgithub_workflow_completed",
 			Help: "Number of workflow runs completed",
 		},
-		[]string{"repository", "workflow_conclusion", "workflow_name"},
+		[]string{"repository", "branch", "workflow_conclusion", "workflow_name"},
 	)
 
 	// Job metrics.
@@ -54,7 +54,7 @@ var (
 			Name: "promgithub_job_status",
 			Help: "Total number of jobs with status",
 		},
-		[]string{"repository", "workflow_name", "job_status", "job_conclusion"},
+		[]string{"repository", "branch", "workflow_name", "job_status", "job_conclusion"},
 	)
 
 	jobDurationHistogram = promauto.NewHistogramVec(
@@ -63,7 +63,7 @@ var (
 			Help:    "Duration of jobs runs in seconds",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"repository", "workflow_name", "job_status", "job_conclusion"},
+		[]string{"repository", "branch", "workflow_name", "job_status", "job_conclusion"},
 	)
 
 	jobQueuedGauge = promauto.NewGaugeVec(
@@ -71,7 +71,7 @@ var (
 			Name: "promgithub_job_queued",
 			Help: "Number of jobs queued",
 		},
-		[]string{"repository", "workflow_name"},
+		[]string{"repository", "branch", "workflow_name"},
 	)
 
 	jobInProgressGauge = promauto.NewGaugeVec(
@@ -79,7 +79,7 @@ var (
 			Name: "promgithub_job_in_progress",
 			Help: "Number of jobs in progress",
 		},
-		[]string{"repository", "workflow_name"},
+		[]string{"repository", "branch", "workflow_name"},
 	)
 
 	jobCompletedGauge = promauto.NewGaugeVec(
@@ -87,7 +87,7 @@ var (
 			Name: "promgithub_job_completed",
 			Help: "Number of jobs completed",
 		},
-		[]string{"repository", "job_conclusion", "workflow_name"},
+		[]string{"repository", "branch", "job_conclusion", "workflow_name"},
 	)
 
 	commitPushedCounter = promauto.NewCounterVec(

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -12,7 +12,7 @@ var (
 			Name: "promgithub_workflow_status",
 			Help: "Total number of workflow runs with status",
 		},
-		[]string{"repository", "branch", "workflow_name", "workflow_status", "conclusion"},
+		[]string{"repository", "workflow_name", "workflow_status", "conclusion"},
 	)
 
 	workflowDurationHistogram = promauto.NewHistogramVec(
@@ -21,7 +21,7 @@ var (
 			Help:    "Duration of workflow runs",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"repository", "branch", "workflow_name", "workflow_status", "conclusion"},
+		[]string{"repository", "workflow_name", "workflow_status", "conclusion"},
 	)
 
 	workflowQueuedGauge = promauto.NewGaugeVec(
@@ -29,7 +29,7 @@ var (
 			Name: "promgithub_workflow_queued",
 			Help: "Number of workflow runs queued",
 		},
-		[]string{"repository", "branch", "workflow_name"},
+		[]string{"repository", "workflow_name"},
 	)
 
 	workflowInProgressGauge = promauto.NewGaugeVec(
@@ -37,7 +37,7 @@ var (
 			Name: "promgithub_workflow_in_progress",
 			Help: "Number of workflow runs in progress",
 		},
-		[]string{"repository", "branch", "workflow_name"},
+		[]string{"repository", "workflow_name"},
 	)
 
 	workflowCompletedGauge = promauto.NewGaugeVec(
@@ -45,7 +45,7 @@ var (
 			Name: "promgithub_workflow_completed",
 			Help: "Number of workflow runs completed",
 		},
-		[]string{"repository", "branch", "workflow_conclusion", "workflow_name"},
+		[]string{"repository", "workflow_conclusion", "workflow_name"},
 	)
 
 	// Job metrics.
@@ -54,7 +54,7 @@ var (
 			Name: "promgithub_job_status",
 			Help: "Total number of jobs with status",
 		},
-		[]string{"runner", "repository", "branch", "workflow_name", "job_name", "job_status", "job_conclusion"},
+		[]string{"repository", "workflow_name", "job_status", "job_conclusion"},
 	)
 
 	jobDurationHistogram = promauto.NewHistogramVec(
@@ -63,7 +63,7 @@ var (
 			Help:    "Duration of jobs runs in seconds",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"runner", "repository", "branch", "workflow_name", "job_name", "job_status", "job_conclusion"},
+		[]string{"repository", "workflow_name", "job_status", "job_conclusion"},
 	)
 
 	jobQueuedGauge = promauto.NewGaugeVec(
@@ -71,7 +71,7 @@ var (
 			Name: "promgithub_job_queued",
 			Help: "Number of jobs queued",
 		},
-		[]string{"runner", "repository", "branch", "workflow_name", "job_name"},
+		[]string{"repository", "workflow_name"},
 	)
 
 	jobInProgressGauge = promauto.NewGaugeVec(
@@ -79,7 +79,7 @@ var (
 			Name: "promgithub_job_in_progress",
 			Help: "Number of jobs in progress",
 		},
-		[]string{"runner", "repository", "branch", "workflow_name", "job_name"},
+		[]string{"repository", "workflow_name"},
 	)
 
 	jobCompletedGauge = promauto.NewGaugeVec(
@@ -87,7 +87,7 @@ var (
 			Name: "promgithub_job_completed",
 			Help: "Number of jobs completed",
 		},
-		[]string{"runner", "repository", "branch", "job_conclusion", "workflow_name", "job_name"},
+		[]string{"repository", "job_conclusion", "workflow_name"},
 	)
 
 	commitPushedCounter = promauto.NewCounterVec(
@@ -95,7 +95,7 @@ var (
 			Name: "promgithub_commit_pushed",
 			Help: "Total number of commits pushed",
 		},
-		[]string{"repository", "branch", "commit_author", "commit_author_email"},
+		[]string{"repository"},
 	)
 
 	pullRequestCounter = promauto.NewCounterVec(
@@ -103,6 +103,6 @@ var (
 			Name: "promgithub_pull_request",
 			Help: "Total number of pull requests",
 		},
-		[]string{"repository", "base_branch", "pull_request_author", "pull_request_status"},
+		[]string{"repository", "base_branch", "pull_request_status"},
 	)
 )

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -28,7 +28,7 @@ func TestWorkflowStatusCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowStatusCounter, strings.NewReader(`
 		# HELP promgithub_workflow_status Total number of workflow runs with status
 		# TYPE promgithub_workflow_status counter
-		promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
+		promgithub_workflow_status{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestJobStatusCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobStatusCounter, strings.NewReader(`
         # HELP promgithub_job_status Total number of jobs with status
         # TYPE promgithub_job_status counter
-        promgithub_job_status{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI"} 1
+        promgithub_job_status{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestCommitsPushedCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(commitPushedCounter, strings.NewReader(`
 		# HELP promgithub_commit_pushed Total number of commits pushed
 		# TYPE promgithub_commit_pushed counter
-		promgithub_commit_pushed{branch="refs/heads/main",commit_author="Author1",commit_author_email="author1@example.com",repository="user/repo"} 1
+		promgithub_commit_pushed{repository="user/repo"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestPullRequestsCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(pullRequestCounter, strings.NewReader(`
 		# HELP promgithub_pull_request Total number of pull requests
 		# TYPE promgithub_pull_request counter
-		promgithub_pull_request{base_branch="main",pull_request_author="user1",pull_request_status="opened",repository="user/repo"} 1
+		promgithub_pull_request{base_branch="main",pull_request_status="opened",repository="user/repo"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -104,20 +104,20 @@ func TestWorkflowDurationHistogram(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowDurationHistogram, strings.NewReader(`
 		# HELP promgithub_workflow_duration Duration of workflow runs
 		# TYPE promgithub_workflow_duration histogram
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.005"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.01"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.025"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.05"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.1"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.25"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.5"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="1"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="2.5"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="5"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="10"} 0
-		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="+Inf"} 1
-		promgithub_workflow_duration_sum{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 3600
-		promgithub_workflow_duration_count{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.005"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.01"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.025"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.05"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.1"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.25"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.5"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="1"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="2.5"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="5"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="10"} 0
+		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="+Inf"} 1
+		promgithub_workflow_duration_sum{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 3600
+		promgithub_workflow_duration_count{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -136,20 +136,20 @@ func TestJobDurationHistogram(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobDurationHistogram, strings.NewReader(`
         # HELP promgithub_job_duration Duration of jobs runs in seconds
         # TYPE promgithub_job_duration histogram
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.005"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.01"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.025"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.05"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.1"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.25"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="0.5"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="1"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="2.5"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="5"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="10"} 0
-        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI",le="+Inf"} 1
-        promgithub_job_duration_sum{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI"} 3600
-        promgithub_job_duration_count{branch="main",job_conclusion="success",job_name="Job1",job_status="completed",repository="user/repo",runner="runner1",workflow_name="CI"} 1
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.005"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.01"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.025"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.05"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.1"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.25"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.5"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="1"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="2.5"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="5"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="10"} 0
+        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="+Inf"} 1
+        promgithub_job_duration_sum{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 3600
+        promgithub_job_duration_count{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestWorkflowQueuedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowQueuedGauge, strings.NewReader(`
         # HELP promgithub_workflow_queued Number of workflow runs queued
         # TYPE promgithub_workflow_queued gauge
-        promgithub_workflow_queued{branch="main",repository="user/repo",workflow_name="CI"} 1
+        promgithub_workflow_queued{repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestWorkflowInProgressGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowInProgressGauge, strings.NewReader(`
         # HELP promgithub_workflow_in_progress Number of workflow runs in progress
         # TYPE promgithub_workflow_in_progress gauge
-        promgithub_workflow_in_progress{branch="main",repository="user/repo",workflow_name="CI"} 1
+        promgithub_workflow_in_progress{repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestWorkflowCompletedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowCompletedGauge, strings.NewReader(`
 		# HELP promgithub_workflow_completed Number of workflow runs completed
 		# TYPE promgithub_workflow_completed gauge
-		promgithub_workflow_completed{branch="main",repository="user/repo",workflow_conclusion="success",workflow_name="CI"} 1
+		promgithub_workflow_completed{repository="user/repo",workflow_conclusion="success",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestJobQueuedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobQueuedGauge, strings.NewReader(`
 		# HELP promgithub_job_queued Number of jobs queued
 		# TYPE promgithub_job_queued gauge
-		promgithub_job_queued{branch="main",job_name="Job1",repository="user/repo",runner="runner1",workflow_name="CI"} 1
+		promgithub_job_queued{repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestJobInProgressGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobInProgressGauge, strings.NewReader(`
 		# HELP promgithub_job_in_progress Number of jobs in progress
 		# TYPE promgithub_job_in_progress gauge
-		promgithub_job_in_progress{branch="main",job_name="Job1",repository="user/repo",runner="runner1",workflow_name="CI"} 1
+		promgithub_job_in_progress{repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJobCompletedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobCompletedGauge, strings.NewReader(`
 		# HELP promgithub_job_completed Number of jobs completed
 		# TYPE promgithub_job_completed gauge
-		promgithub_job_completed{branch="main",job_conclusion="success",job_name="Job1",repository="user/repo",runner="runner1",workflow_name="CI"} 1
+		promgithub_job_completed{job_conclusion="success",repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -28,7 +28,7 @@ func TestWorkflowStatusCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowStatusCounter, strings.NewReader(`
 		# HELP promgithub_workflow_status Total number of workflow runs with status
 		# TYPE promgithub_workflow_status counter
-		promgithub_workflow_status{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
+		promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestJobStatusCounter(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobStatusCounter, strings.NewReader(`
         # HELP promgithub_job_status Total number of jobs with status
         # TYPE promgithub_job_status counter
-        promgithub_job_status{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
+        promgithub_job_status{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -104,20 +104,20 @@ func TestWorkflowDurationHistogram(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowDurationHistogram, strings.NewReader(`
 		# HELP promgithub_workflow_duration Duration of workflow runs
 		# TYPE promgithub_workflow_duration histogram
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.005"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.01"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.025"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.05"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.1"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.25"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.5"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="1"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="2.5"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="5"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="10"} 0
-		promgithub_workflow_duration_bucket{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="+Inf"} 1
-		promgithub_workflow_duration_sum{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 3600
-		promgithub_workflow_duration_count{conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.005"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.01"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.025"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.05"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.1"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.25"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="0.5"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="1"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="2.5"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="5"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="10"} 0
+		promgithub_workflow_duration_bucket{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed",le="+Inf"} 1
+		promgithub_workflow_duration_sum{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 3600
+		promgithub_workflow_duration_count{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -136,20 +136,20 @@ func TestJobDurationHistogram(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobDurationHistogram, strings.NewReader(`
         # HELP promgithub_job_duration Duration of jobs runs in seconds
         # TYPE promgithub_job_duration histogram
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.005"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.01"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.025"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.05"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.1"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.25"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.5"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="1"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="2.5"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="5"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="10"} 0
-        promgithub_job_duration_bucket{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="+Inf"} 1
-        promgithub_job_duration_sum{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 3600
-        promgithub_job_duration_count{job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.005"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.01"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.025"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.05"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.1"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.25"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="0.5"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="1"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="2.5"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="5"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="10"} 0
+        promgithub_job_duration_bucket{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI",le="+Inf"} 1
+        promgithub_job_duration_sum{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 3600
+        promgithub_job_duration_count{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestWorkflowQueuedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowQueuedGauge, strings.NewReader(`
         # HELP promgithub_workflow_queued Number of workflow runs queued
         # TYPE promgithub_workflow_queued gauge
-        promgithub_workflow_queued{repository="user/repo",workflow_name="CI"} 1
+        promgithub_workflow_queued{branch="main",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestWorkflowInProgressGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowInProgressGauge, strings.NewReader(`
         # HELP promgithub_workflow_in_progress Number of workflow runs in progress
         # TYPE promgithub_workflow_in_progress gauge
-        promgithub_workflow_in_progress{repository="user/repo",workflow_name="CI"} 1
+        promgithub_workflow_in_progress{branch="main",repository="user/repo",workflow_name="CI"} 1
     `)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestWorkflowCompletedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(workflowCompletedGauge, strings.NewReader(`
 		# HELP promgithub_workflow_completed Number of workflow runs completed
 		# TYPE promgithub_workflow_completed gauge
-		promgithub_workflow_completed{repository="user/repo",workflow_conclusion="success",workflow_name="CI"} 1
+		promgithub_workflow_completed{branch="main",repository="user/repo",workflow_conclusion="success",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestJobQueuedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobQueuedGauge, strings.NewReader(`
 		# HELP promgithub_job_queued Number of jobs queued
 		# TYPE promgithub_job_queued gauge
-		promgithub_job_queued{repository="user/repo",workflow_name="CI"} 1
+		promgithub_job_queued{branch="main",repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestJobInProgressGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobInProgressGauge, strings.NewReader(`
 		# HELP promgithub_job_in_progress Number of jobs in progress
 		# TYPE promgithub_job_in_progress gauge
-		promgithub_job_in_progress{repository="user/repo",workflow_name="CI"} 1
+		promgithub_job_in_progress{branch="main",repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJobCompletedGauge(t *testing.T) {
 	if err := testutil.CollectAndCompare(jobCompletedGauge, strings.NewReader(`
 		# HELP promgithub_job_completed Number of jobs completed
 		# TYPE promgithub_job_completed gauge
-		promgithub_job_completed{job_conclusion="success",repository="user/repo",workflow_name="CI"} 1
+		promgithub_job_completed{branch="main",job_conclusion="success",repository="user/repo",workflow_name="CI"} 1
 	`)); err != nil {
 		t.Errorf("unexpected metrics: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove high-cardinality labels from default workflow, job, push, and pull request metrics
- switch hot-path metric updates to WithLabelValues to avoid per-update label map allocation
- document the lower-cardinality metric contract and upgrade impact

## Testing
- go test ./...

Closes #38