### PR TITLE
test: add HTTP integration coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ permissions:
   security-events: write
 
 jobs:
-  build:
-    name: Build promgithub
+  unit-and-build:
+    name: Unit, lint, build, and coverage
     runs-on: ubuntu-24.04
 
     steps:
@@ -53,8 +53,8 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Test
-        run: make test
+      - name: Unit Tests
+        run: make test-unit
 
       - name: Coverage
         run: make coverage
@@ -64,3 +64,29 @@ jobs:
 
       - name: Container Security Scan
         run: make container-security
+
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        id: environment
+        run: |
+          GOVERSION=$(make go-version)
+          echo "GOVERSION=${GOVERSION}" >> $GITHUB_ENV
+
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        id: go
+        with:
+          go-version: ${{ env.GOVERSION }}
+
+      - name: Install Tools and Dependencies
+        run: make deps
+
+      - name: Integration Tests
+        run: make test-integration

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
         run: make build
 
       - name: Unit Tests
-        run: make test-unit
+        run: make unit-test
 
       - name: Coverage
         run: make coverage
@@ -89,4 +89,4 @@ jobs:
         run: make deps
 
       - name: Integration Tests
-        run: make test-integration
+        run: make integration-test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   unit-and-build:
-    name: Unit, lint, build, and coverage
+    name: build and test
     runs-on: ubuntu-24.04
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build container container-security cross-platform debug release test test-all go-version coverage fmt lint deps security clean dev-setup
+.PHONY: build container container-security cross-platform debug release test test-unit test-integration test-suite test-all go-version coverage fmt lint deps security clean dev-setup
 
 include version
 
@@ -31,10 +31,19 @@ debug: LDFLAGS := $(LDFLAGS_DBG)
 debug: TARGET := $(TARGET)-debug
 debug: build
 
-test: PROMGITHUB_WEBHOOK_SECRET := test-secret
-test: ## Run unit tests
+test: test-unit ## Backward-compatible alias for unit tests
+
+test-unit: PROMGITHUB_WEBHOOK_SECRET := test-secret
+test-unit: ## Run unit tests
 	@echo "${COLOR_GREEN}Running Unit Tests..${COLOR_RESET}"
 	@go test -v $(SRC)
+
+test-integration: PROMGITHUB_WEBHOOK_SECRET := test-secret
+test-integration: ## Run integration tests
+	@echo "${COLOR_GREEN}Running Integration Tests..${COLOR_RESET}"
+	@go test -tags=integration -v $(SRC)
+
+test-suite: test-unit test-integration ## Run the full Go test suite
 
 coverage: ## Run unit tests with coverage
 	@echo "${COLOR_GREEN}Running Coverage Checks..${COLOR_RESET}"
@@ -97,7 +106,7 @@ container-security: mkdir ## Run container security scan
 	@echo "${COLOR_GREEN}Running container security scan...${COLOR_RESET}"
 	@trivy image --format json --output build/trivy-report.json $(CONTAINER_REGISTRY):$(VERSION)
 
-test-all: test coverage security lint ## Run all tests and checks
+test-all: test-suite coverage security lint ## Run all tests and checks
 
 dev-setup: deps setup-commit-hooks ## Setup development environment
 	@echo "Development environment ready"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build container container-security cross-platform debug release test test-unit test-integration test-suite test-all go-version coverage fmt lint deps security clean dev-setup
+.PHONY: build container container-security cross-platform debug release test unit-test integration-test test-all go-version coverage fmt lint deps security clean dev-setup
 
 include version
 
@@ -31,19 +31,17 @@ debug: LDFLAGS := $(LDFLAGS_DBG)
 debug: TARGET := $(TARGET)-debug
 debug: build
 
-test: test-unit ## Backward-compatible alias for unit tests
+test: unit-test integration-test ## Run the full Go test suite
 
-test-unit: PROMGITHUB_WEBHOOK_SECRET := test-secret
-test-unit: ## Run unit tests
+unit-test: PROMGITHUB_WEBHOOK_SECRET := test-secret
+unit-test: ## Run unit tests
 	@echo "${COLOR_GREEN}Running Unit Tests..${COLOR_RESET}"
 	@go test -v $(SRC)
 
-test-integration: PROMGITHUB_WEBHOOK_SECRET := test-secret
-test-integration: ## Run integration tests
+integration-test: PROMGITHUB_WEBHOOK_SECRET := test-secret
+integration-test: ## Run integration tests
 	@echo "${COLOR_GREEN}Running Integration Tests..${COLOR_RESET}"
 	@go test -tags=integration -v $(SRC)
-
-test-suite: test-unit test-integration ## Run the full Go test suite
 
 coverage: ## Run unit tests with coverage
 	@echo "${COLOR_GREEN}Running Coverage Checks..${COLOR_RESET}"
@@ -106,7 +104,7 @@ container-security: mkdir ## Run container security scan
 	@echo "${COLOR_GREEN}Running container security scan...${COLOR_RESET}"
 	@trivy image --format json --output build/trivy-report.json $(CONTAINER_REGISTRY):$(VERSION)
 
-test-all: test-suite coverage security lint ## Run all tests and checks
+test-all: test coverage security lint ## Run all tests and checks
 
 dev-setup: deps setup-commit-hooks ## Setup development environment
 	@echo "Development environment ready"

--- a/src/async_test.go
+++ b/src/async_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package main
 
 import (

--- a/src/github_test.go
+++ b/src/github_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package main
 
 import (

--- a/src/integration_test.go
+++ b/src/integration_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+func TestWebhookMetricsIntegration(t *testing.T) {
+	testCases := []struct {
+		name           string
+		eventType      string
+		fixture        string
+		expectedStatus int
+		expectedMetric string
+	}{
+		{
+			name:           "workflow run updates workflow metrics",
+			eventType:      "workflow_run",
+			fixture:        "../test_data/workflow_run.json",
+			expectedStatus: http.StatusAccepted,
+			expectedMetric: `promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1`,
+		},
+		{
+			name:           "workflow job updates job metrics",
+			eventType:      "workflow_job",
+			fixture:        "../test_data/workflow_job.json",
+			expectedStatus: http.StatusAccepted,
+			expectedMetric: `promgithub_job_status{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1`,
+		},
+		{
+			name:           "push updates commit metrics",
+			eventType:      "push",
+			fixture:        "../test_data/push.json",
+			expectedStatus: http.StatusAccepted,
+			expectedMetric: `promgithub_commit_pushed{repository="user/repo"} 1`,
+		},
+		{
+			name:           "pull request updates pull request metrics",
+			eventType:      "pull_request",
+			fixture:        "../test_data/pull_request.json",
+			expectedStatus: http.StatusAccepted,
+			expectedMetric: `promgithub_pull_request{base_branch="main",pull_request_status="opened",repository="user/repo"} 1`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newIntegrationTestServer(t)
+			defer server.Close()
+
+			body := mustReadFixture(t, tc.fixture)
+			resp := sendWebhookRequest(t, server.URL, tc.eventType, body, "delivery-1")
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tc.expectedStatus {
+				t.Fatalf("expected status %d, got %d", tc.expectedStatus, resp.StatusCode)
+			}
+
+			metrics := waitForMetricsSubstring(t, server.URL, tc.expectedMetric)
+			if !strings.Contains(metrics, tc.expectedMetric) {
+				t.Fatalf("expected metrics to contain %q, got:\n%s", tc.expectedMetric, metrics)
+			}
+		})
+	}
+}
+
+func TestWebhookInvalidSignatureIntegration(t *testing.T) {
+	server := newIntegrationTestServer(t)
+	defer server.Close()
+
+	body := mustReadFixture(t, "../test_data/workflow_run.json")
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/webhook", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Hub-Signature-256", "sha256=invalid")
+	req.Header.Set("X-GitHub-Event", "workflow_run")
+	req.Header.Set("X-GitHub-Delivery", "delivery-invalid")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, resp.StatusCode)
+	}
+
+	metrics := mustFetchMetrics(t, server.URL)
+	if strings.Contains(metrics, `promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1`) {
+		t.Fatalf("workflow metrics changed after invalid signature:\n%s", metrics)
+	}
+}
+
+func TestWebhookUnsupportedEventIntegration(t *testing.T) {
+	server := newIntegrationTestServer(t)
+	defer server.Close()
+
+	body := mustReadFixture(t, "../test_data/workflow_run.json")
+	resp := sendWebhookRequest(t, server.URL, "unknown_event", body, "delivery-unsupported")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, resp.StatusCode)
+	}
+
+	metrics := mustFetchMetrics(t, server.URL)
+	if strings.Contains(metrics, `promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1`) {
+		t.Fatalf("unsupported event unexpectedly updated workflow metrics:\n%s", metrics)
+	}
+}
+
+func TestHealthAndMetricsEndpointsIntegration(t *testing.T) {
+	server := newIntegrationTestServer(t)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("failed to get health endpoint: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected health status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	metricsResp, err := http.Get(server.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed to get metrics endpoint: %v", err)
+	}
+	defer func() { _ = metricsResp.Body.Close() }()
+
+	if metricsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected metrics status %d, got %d", http.StatusOK, metricsResp.StatusCode)
+	}
+}
+
+func newIntegrationTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	resetIntegrationTestMetrics()
+
+	githubWebhookSecret = []byte("integration-test-secret")
+	stateStore = newInMemoryStateStore()
+	eventProcessor = newAsyncEventProcessor(asyncProcessorConfig{WorkerCount: 1, QueueSize: 8}, zap.NewNop())
+	eventProcessor.Start()
+	t.Cleanup(func() {
+		eventProcessor.Stop()
+		eventProcessor = nil
+		stateStore = nil
+	})
+
+	router := setupRouter(zap.NewNop(), defaultServiceMetrics, prometheus.DefaultGatherer)
+	return httptest.NewServer(router)
+}
+
+func resetIntegrationTestMetrics() {
+	workflowStatusCounter.Reset()
+	workflowDurationHistogram.Reset()
+	workflowQueuedGauge.Reset()
+	workflowInProgressGauge.Reset()
+	workflowCompletedGauge.Reset()
+	jobStatusCounter.Reset()
+	jobDurationHistogram.Reset()
+	jobQueuedGauge.Reset()
+	jobInProgressGauge.Reset()
+	jobCompletedGauge.Reset()
+	commitPushedCounter.Reset()
+	pullRequestCounter.Reset()
+	asyncProcessedEventsCounter.Reset()
+	asyncEventsDroppedCounter.Reset()
+	asyncProcessingFailuresCounter.Reset()
+	asyncProcessingDurationHistogram.Reset()
+	defaultServiceMetrics.apiCallsCounter.Reset()
+	defaultServiceMetrics.requestDurationHistogram.Reset()
+	asyncQueueDepthGauge.Set(0)
+	asyncQueueCapacityGauge.Set(0)
+	asyncWorkerCountGauge.Set(0)
+}
+
+func mustReadFixture(t *testing.T, path string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	return body
+}
+
+func sendWebhookRequest(t *testing.T, serverURL, eventType string, body []byte, deliveryID string) *http.Response {
+	t.Helper()
+	signature := webhookSignature(body, githubWebhookSecret)
+	req, err := http.NewRequest(http.MethodPost, serverURL+"/webhook", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Hub-Signature-256", signature)
+	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("X-GitHub-Delivery", deliveryID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	return resp
+}
+
+func webhookSignature(body, secret []byte) string {
+	h := hmac.New(sha256.New, secret)
+	_, _ = h.Write(body)
+	return fmt.Sprintf("sha256=%s", hex.EncodeToString(h.Sum(nil)))
+}
+
+func mustFetchMetrics(t *testing.T, serverURL string) string {
+	t.Helper()
+
+	resp, err := http.Get(serverURL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed to fetch metrics: %v", err)
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("failed to read metrics response: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected metrics status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	return string(body)
+}
+
+func waitForMetricsSubstring(t *testing.T, serverURL, needle string) string {
+	t.Helper()
+
+	var lastBody string
+	for i := 0; i < 50; i++ {
+		lastBody = mustFetchMetrics(t, serverURL)
+		if strings.Contains(lastBody, needle) {
+			return lastBody
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return lastBody
+}

--- a/src/integration_test.go
+++ b/src/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package main
 
 import (
@@ -18,7 +20,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestWebhookMetricsIntegration(t *testing.T) {
+func TestIntegrationWebhookMetrics(t *testing.T) {
 	testCases := []struct {
 		name           string
 		eventType      string
@@ -29,28 +31,28 @@ func TestWebhookMetricsIntegration(t *testing.T) {
 		{
 			name:           "workflow run updates workflow metrics",
 			eventType:      "workflow_run",
-			fixture:        "../test_data/workflow_run.json",
+			fixture:        "workflow_run.json",
 			expectedStatus: http.StatusAccepted,
 			expectedMetric: `promgithub_workflow_status{branch="main",conclusion="success",repository="user/repo",workflow_name="CI",workflow_status="completed"} 1`,
 		},
 		{
 			name:           "workflow job updates job metrics",
 			eventType:      "workflow_job",
-			fixture:        "../test_data/workflow_job.json",
+			fixture:        "workflow_job.json",
 			expectedStatus: http.StatusAccepted,
 			expectedMetric: `promgithub_job_status{branch="main",job_conclusion="success",job_status="completed",repository="user/repo",workflow_name="CI"} 1`,
 		},
 		{
 			name:           "push updates commit metrics",
 			eventType:      "push",
-			fixture:        "../test_data/push.json",
+			fixture:        "push.json",
 			expectedStatus: http.StatusAccepted,
 			expectedMetric: `promgithub_commit_pushed{repository="user/repo"} 1`,
 		},
 		{
 			name:           "pull request updates pull request metrics",
 			eventType:      "pull_request",
-			fixture:        "../test_data/pull_request.json",
+			fixture:        "pull_request.json",
 			expectedStatus: http.StatusAccepted,
 			expectedMetric: `promgithub_pull_request{base_branch="main",pull_request_status="opened",repository="user/repo"} 1`,
 		},
@@ -77,11 +79,11 @@ func TestWebhookMetricsIntegration(t *testing.T) {
 	}
 }
 
-func TestWebhookInvalidSignatureIntegration(t *testing.T) {
+func TestIntegrationWebhookInvalidSignature(t *testing.T) {
 	server := newIntegrationTestServer(t)
 	defer server.Close()
 
-	body := mustReadFixture(t, "../test_data/workflow_run.json")
+	body := mustReadFixture(t, "workflow_run.json")
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/webhook", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -106,11 +108,11 @@ func TestWebhookInvalidSignatureIntegration(t *testing.T) {
 	}
 }
 
-func TestWebhookUnsupportedEventIntegration(t *testing.T) {
+func TestIntegrationWebhookUnsupportedEvent(t *testing.T) {
 	server := newIntegrationTestServer(t)
 	defer server.Close()
 
-	body := mustReadFixture(t, "../test_data/workflow_run.json")
+	body := mustReadFixture(t, "workflow_run.json")
 	resp := sendWebhookRequest(t, server.URL, "unknown_event", body, "delivery-unsupported")
 	defer func() { _ = resp.Body.Close() }()
 
@@ -124,7 +126,7 @@ func TestWebhookUnsupportedEventIntegration(t *testing.T) {
 	}
 }
 
-func TestHealthAndMetricsEndpointsIntegration(t *testing.T) {
+func TestIntegrationHealthAndMetricsEndpoints(t *testing.T) {
 	server := newIntegrationTestServer(t)
 	defer server.Close()
 
@@ -191,8 +193,18 @@ func resetIntegrationTestMetrics() {
 	asyncWorkerCountGauge.Set(0)
 }
 
-func mustReadFixture(t *testing.T, path string) []byte {
+func mustReadFixture(t *testing.T, name string) []byte {
 	t.Helper()
+	allowed := map[string]string{
+		"workflow_run.json": "../test_data/workflow_run.json",
+		"workflow_job.json": "../test_data/workflow_job.json",
+		"push.json":         "../test_data/push.json",
+		"pull_request.json": "../test_data/pull_request.json",
+	}
+	path, ok := allowed[name]
+	if !ok {
+		t.Fatalf("unknown fixture %q", name)
+	}
 	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read fixture %s: %v", path, err)

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package main
 
 import (

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package main
 
 import (

--- a/src/redis_test.go
+++ b/src/redis_test.go
@@ -1,57 +1,12 @@
+//go:build !integration
+
 package main
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
 )
-
-type inMemoryStateStore struct {
-	deliveries map[string]struct{}
-	workflow   map[int]RunState
-	jobs       map[int]RunState
-}
-
-func newInMemoryStateStore() *inMemoryStateStore {
-	return &inMemoryStateStore{
-		deliveries: map[string]struct{}{},
-		workflow:   map[int]RunState{},
-		jobs:       map[int]RunState{},
-	}
-}
-
-func (s *inMemoryStateStore) MarkDeliveryProcessed(_ context.Context, deliveryID string) (bool, error) {
-	if _, ok := s.deliveries[deliveryID]; ok {
-		return false, nil
-	}
-	s.deliveries[deliveryID] = struct{}{}
-	return true, nil
-}
-
-func (s *inMemoryStateStore) GetWorkflowRun(_ context.Context, runID int) (RunState, bool, error) {
-	state, ok := s.workflow[runID]
-	return state, ok, nil
-}
-
-func (s *inMemoryStateStore) UpdateWorkflowRun(_ context.Context, runID int, state RunState) error {
-	s.workflow[runID] = state
-	return nil
-}
-
-func (s *inMemoryStateStore) GetWorkflowJob(_ context.Context, jobID int) (RunState, bool, error) {
-	state, ok := s.jobs[jobID]
-	return state, ok, nil
-}
-
-func (s *inMemoryStateStore) UpdateWorkflowJob(_ context.Context, jobID int, state RunState) error {
-	s.jobs[jobID] = state
-	return nil
-}
-
-func (s *inMemoryStateStore) Close() error {
-	return nil
-}
 
 func TestLoadRedisConfigFromEnv(t *testing.T) {
 	for _, key := range []string{

--- a/src/test_support_test.go
+++ b/src/test_support_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "context"
+
+type inMemoryStateStore struct {
+	deliveries map[string]struct{}
+	workflow   map[int]RunState
+	jobs       map[int]RunState
+}
+
+func newInMemoryStateStore() *inMemoryStateStore {
+	return &inMemoryStateStore{
+		deliveries: map[string]struct{}{},
+		workflow:   map[int]RunState{},
+		jobs:       map[int]RunState{},
+	}
+}
+
+func (s *inMemoryStateStore) MarkDeliveryProcessed(_ context.Context, deliveryID string) (bool, error) {
+	if _, ok := s.deliveries[deliveryID]; ok {
+		return false, nil
+	}
+	s.deliveries[deliveryID] = struct{}{}
+	return true, nil
+}
+
+func (s *inMemoryStateStore) GetWorkflowRun(_ context.Context, runID int) (RunState, bool, error) {
+	state, ok := s.workflow[runID]
+	return state, ok, nil
+}
+
+func (s *inMemoryStateStore) UpdateWorkflowRun(_ context.Context, runID int, state RunState) error {
+	s.workflow[runID] = state
+	return nil
+}
+
+func (s *inMemoryStateStore) GetWorkflowJob(_ context.Context, jobID int) (RunState, bool, error) {
+	state, ok := s.jobs[jobID]
+	return state, ok, nil
+}
+
+func (s *inMemoryStateStore) UpdateWorkflowJob(_ context.Context, jobID int, state RunState) error {
+	s.jobs[jobID] = state
+	return nil
+}
+
+func (s *inMemoryStateStore) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- add in-process HTTP integration tests for webhook-to-metrics flows
- validate workflow, job, push, and pull request events through real `/webhook` and `/metrics` endpoints
- cover health endpoint, invalid signature handling, and unsupported events

Closes #53

## Testing
- go test ./...
