### PR TITLE
Split delivery and run state interfaces

### DIFF
--- a/src/github.go
+++ b/src/github.go
@@ -88,8 +88,10 @@ const (
 )
 
 var (
-	stateStore     StateStore
-	eventProcessor *asyncEventProcessor
+	deliveryStateStore    deliveryStateBackend
+	workflowRunStateStore workflowRunStateBackend
+	workflowJobStateStore workflowJobStateBackend
+	eventProcessor        *asyncEventProcessor
 )
 
 func validateHMAC(body []byte, signature string, secret []byte) bool {
@@ -182,17 +184,12 @@ func updateTrackedRunMetrics(
 	ctx context.Context,
 	id int,
 	details runMetricDetails,
-	store runStoreMethods,
+	store runTransitionStore,
 	entityName string,
 	metricKind runMetricKind,
 ) {
-	var storeAdapter runTransitionStore
-	if stateStore != nil {
-		storeAdapter = runStoreAdapter{methods: store}
-	}
-
 	processor := &runTransitionProcessor{
-		store:      storeAdapter,
+		store:      store,
 		recorder:   metricRunTransitionRecorder{kind: metricKind, recorder: defaultMetricRecorder},
 		logger:     logger,
 		entityName: entityName,
@@ -200,26 +197,20 @@ func updateTrackedRunMetrics(
 	processor.Apply(ctx, id, details)
 }
 
-func workflowRunStoreMethods() runStoreMethods {
-	return runStoreMethods{
-		get: func(ctx context.Context, id int) (RunState, bool, error) {
-			return stateStore.GetWorkflowRun(ctx, id)
-		},
-		update: func(ctx context.Context, id int, state RunState) error {
-			return stateStore.UpdateWorkflowRun(ctx, id, state)
-		},
+func workflowRunTransitionStore() runTransitionStore {
+	if workflowRunStateStore == nil {
+		return nil
 	}
+
+	return workflowRunStateAdapter{store: workflowRunStateStore}
 }
 
-func workflowJobStoreMethods() runStoreMethods {
-	return runStoreMethods{
-		get: func(ctx context.Context, id int) (RunState, bool, error) {
-			return stateStore.GetWorkflowJob(ctx, id)
-		},
-		update: func(ctx context.Context, id int, state RunState) error {
-			return stateStore.UpdateWorkflowJob(ctx, id, state)
-		},
+func workflowJobTransitionStore() runTransitionStore {
+	if workflowJobStateStore == nil {
+		return nil
 	}
+
+	return workflowJobStateAdapter{store: workflowJobStateStore}
 }
 
 func updateWorkflowMetrics(ctx context.Context, body []byte) {
@@ -242,7 +233,7 @@ func updateWorkflowMetrics(ctx context.Context, body []byte) {
 			startedAt:  payload.Workflow.CreatedAt,
 			endedAt:    payload.Workflow.UpdatedAt,
 		},
-		workflowRunStoreMethods(),
+		workflowRunTransitionStore(),
 		githubEventWorkflowRun,
 		runMetricKindWorkflow,
 	)
@@ -268,7 +259,7 @@ func updateJobMetrics(ctx context.Context, body []byte) {
 			startedAt:  payload.Job.StartedAt,
 			endedAt:    payload.Job.CompletedAt,
 		},
-		workflowJobStoreMethods(),
+		workflowJobTransitionStore(),
 		githubEventWorkflowJob,
 		runMetricKindJob,
 	)

--- a/src/github_test.go
+++ b/src/github_test.go
@@ -52,7 +52,9 @@ func resetWebhookTestState() {
 	asyncWorkerCountGauge.Set(0)
 	githubWebhookSecret = []byte("test-secret")
 	logger = zap.NewNop()
-	stateStore = nil
+	deliveryStateStore = nil
+	workflowRunStateStore = nil
+	workflowJobStateStore = nil
 	eventProcessor = nil
 	deliveryDeduperCache = newDeliveryDeduper(defaultDeliveryRetention, defaultDeliveryCacheEntries)
 }
@@ -174,8 +176,7 @@ func TestUnknownEvent(t *testing.T) {
 
 func TestDuplicateDeliveryIsIgnored(t *testing.T) {
 	resetWebhookTestState()
-	stateStore = newInMemoryStateStore()
-	defer func() { stateStore = nil }()
+	useInMemoryStateBackends(t)
 
 	body, err := os.ReadFile("../test_data/workflow_run.json")
 	if err != nil {
@@ -215,8 +216,7 @@ func TestDuplicateDeliveryIsIgnored(t *testing.T) {
 
 func TestDuplicateDeliveryIsDroppedInMetricsEndpoint(t *testing.T) {
 	resetWebhookTestState()
-	stateStore = newInMemoryStateStore()
-	defer func() { stateStore = nil }()
+	useInMemoryStateBackends(t)
 
 	body, err := os.ReadFile("../test_data/workflow_run.json")
 	if err != nil {

--- a/src/integration_test.go
+++ b/src/integration_test.go
@@ -196,9 +196,14 @@ func TestIntegrationDuplicateDeliveryDoesNotInflateMetrics(t *testing.T) {
 }
 
 func TestIntegrationDeliveryStoreFailurePreventsWebhookProcessing(t *testing.T) {
-	server := newIntegrationTestServerWithStateStore(t, asyncProcessorConfig{WorkerCount: 1, QueueSize: 8}, failingDeliveryStateStore{
-		inMemoryStateStore: newInMemoryStateStore(),
-	})
+	runStore := newInMemoryStateStore()
+	server := newIntegrationTestServerWithStateBackends(
+		t,
+		asyncProcessorConfig{WorkerCount: 1, QueueSize: 8},
+		failingDeliveryStore{},
+		runStore,
+		runStore,
+	)
 	defer server.Close()
 
 	body := mustReadFixture(t, "workflow_run.json")
@@ -378,12 +383,33 @@ func newIntegrationTestServerWithAsyncConfig(t *testing.T, cfg asyncProcessorCon
 	return newIntegrationTestServerWithStateStore(t, cfg, newInMemoryStateStore())
 }
 
-func newIntegrationTestServerWithStateStore(t *testing.T, cfg asyncProcessorConfig, store StateStore) *httptest.Server {
+func newIntegrationTestServerWithStateStore(
+	t *testing.T,
+	cfg asyncProcessorConfig,
+	store interface {
+		deliveryStateBackend
+		workflowRunStateBackend
+		workflowJobStateBackend
+	},
+) *httptest.Server {
+	t.Helper()
+	return newIntegrationTestServerWithStateBackends(t, cfg, store, store, store)
+}
+
+func newIntegrationTestServerWithStateBackends(
+	t *testing.T,
+	cfg asyncProcessorConfig,
+	deliveryStore deliveryStateBackend,
+	workflowRunStore workflowRunStateBackend,
+	workflowJobStore workflowJobStateBackend,
+) *httptest.Server {
 	t.Helper()
 	resetIntegrationTestMetrics()
 
 	githubWebhookSecret = []byte("integration-test-secret")
-	stateStore = store
+	deliveryStateStore = deliveryStore
+	workflowRunStateStore = workflowRunStore
+	workflowJobStateStore = workflowJobStore
 	eventProcessor = newAsyncEventProcessor(cfg, zap.NewNop())
 	eventProcessor.Start()
 	t.Cleanup(func() {
@@ -391,18 +417,18 @@ func newIntegrationTestServerWithStateStore(t *testing.T, cfg asyncProcessorConf
 			eventProcessor.Stop()
 		}
 		eventProcessor = nil
-		stateStore = nil
+		deliveryStateStore = nil
+		workflowRunStateStore = nil
+		workflowJobStateStore = nil
 	})
 
 	router := setupRouter(zap.NewNop(), defaultServiceMetrics, prometheus.DefaultGatherer)
 	return httptest.NewServer(router)
 }
 
-type failingDeliveryStateStore struct {
-	*inMemoryStateStore
-}
+type failingDeliveryStore struct{}
 
-func (s failingDeliveryStateStore) MarkDeliveryProcessed(context.Context, string) (bool, error) {
+func (s failingDeliveryStore) MarkDeliveryProcessed(context.Context, string) (bool, error) {
 	return false, errors.New("delivery store unavailable")
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -249,12 +249,15 @@ func main() {
 		logger.Fatal("Invalid Redis configuration", zap.Error(err))
 	}
 	if redisEnabled {
-		stateStore, err = NewRedisStateStore(redisConfig)
+		redisStore, err := NewRedisStateStore(redisConfig)
 		if err != nil {
 			logger.Fatal("Unable to initialize Redis state store", zap.Error(err))
 		}
+		deliveryStateStore = redisStore
+		workflowRunStateStore = redisStore
+		workflowJobStateStore = redisStore
 		defer func() {
-			if closeErr := stateStore.Close(); closeErr != nil {
+			if closeErr := redisStore.Close(); closeErr != nil {
 				logger.Warn("Failed to close Redis state store", zap.Error(closeErr))
 			}
 		}()

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
+// These stores are intentionally parallel so each test satisfies only the run-state interface it exercises.
 type workflowRunOnlyTestStore struct {
 	state   RunState
 	found   bool
@@ -61,7 +62,11 @@ func TestWorkflowMetricsUseWorkflowRunStateWithoutDeliveryState(t *testing.T) {
 	workflowCompletedGauge.Reset()
 	workflowDurationHistogram.Reset()
 
-	updateWorkflowMetrics(context.Background(), readMetricFixture(t, "workflow_run.json"))
+	body, err := os.ReadFile("../test_data/workflow_run.json")
+	if err != nil {
+		t.Fatalf("Failed to read test data file: %v", err)
+	}
+	updateWorkflowMetrics(context.Background(), body)
 
 	assertCompletedStateUpdate(t, "workflow run", store.updates)
 }
@@ -76,30 +81,13 @@ func TestJobMetricsUseWorkflowJobStateWithoutDeliveryOrRunState(t *testing.T) {
 	jobCompletedGauge.Reset()
 	jobDurationHistogram.Reset()
 
-	updateJobMetrics(context.Background(), readMetricFixture(t, "workflow_job.json"))
-
-	assertCompletedStateUpdate(t, "workflow job", store.updates)
-}
-
-func readMetricFixture(t *testing.T, name string) []byte {
-	t.Helper()
-
-	var (
-		body []byte
-		err  error
-	)
-	switch name {
-	case "workflow_run.json":
-		body, err = os.ReadFile("../test_data/workflow_run.json")
-	case "workflow_job.json":
-		body, err = os.ReadFile("../test_data/workflow_job.json")
-	default:
-		t.Fatalf("unknown metric fixture %q", name)
-	}
+	body, err := os.ReadFile("../test_data/workflow_job.json")
 	if err != nil {
 		t.Fatalf("Failed to read test data file: %v", err)
 	}
-	return body
+	updateJobMetrics(context.Background(), body)
+
+	assertCompletedStateUpdate(t, "workflow job", store.updates)
 }
 
 func assertCompletedStateUpdate(t *testing.T, entity string, updates []RunState) {

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -12,10 +12,105 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
+type workflowRunOnlyTestStore struct {
+	state   RunState
+	found   bool
+	updates []RunState
+}
+
+func (s *workflowRunOnlyTestStore) GetWorkflowRun(_ context.Context, _ int) (RunState, bool, error) {
+	return s.state, s.found, nil
+}
+
+func (s *workflowRunOnlyTestStore) UpdateWorkflowRun(_ context.Context, _ int, state RunState) error {
+	s.state = state
+	s.found = true
+	s.updates = append(s.updates, state)
+	return nil
+}
+
+type workflowJobOnlyTestStore struct {
+	state   RunState
+	found   bool
+	updates []RunState
+}
+
+func (s *workflowJobOnlyTestStore) GetWorkflowJob(_ context.Context, _ int) (RunState, bool, error) {
+	return s.state, s.found, nil
+}
+
+func (s *workflowJobOnlyTestStore) UpdateWorkflowJob(_ context.Context, _ int, state RunState) error {
+	s.state = state
+	s.found = true
+	s.updates = append(s.updates, state)
+	return nil
+}
+
 func withInMemoryStateStore(t *testing.T) {
-	oldStore := stateStore
-	stateStore = newInMemoryStateStore()
-	t.Cleanup(func() { stateStore = oldStore })
+	t.Helper()
+	useInMemoryStateBackends(t)
+}
+
+func TestWorkflowMetricsUseWorkflowRunStateWithoutDeliveryState(t *testing.T) {
+	store := &workflowRunOnlyTestStore{}
+	useStateBackends(t, nil, store, nil)
+
+	workflowStatusCounter.Reset()
+	workflowQueuedGauge.Reset()
+	workflowInProgressGauge.Reset()
+	workflowCompletedGauge.Reset()
+	workflowDurationHistogram.Reset()
+
+	updateWorkflowMetrics(context.Background(), readMetricFixture(t, "workflow_run.json"))
+
+	assertCompletedStateUpdate(t, "workflow run", store.updates)
+}
+
+func TestJobMetricsUseWorkflowJobStateWithoutDeliveryOrRunState(t *testing.T) {
+	store := &workflowJobOnlyTestStore{}
+	useStateBackends(t, nil, nil, store)
+
+	jobStatusCounter.Reset()
+	jobQueuedGauge.Reset()
+	jobInProgressGauge.Reset()
+	jobCompletedGauge.Reset()
+	jobDurationHistogram.Reset()
+
+	updateJobMetrics(context.Background(), readMetricFixture(t, "workflow_job.json"))
+
+	assertCompletedStateUpdate(t, "workflow job", store.updates)
+}
+
+func readMetricFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	var (
+		body []byte
+		err  error
+	)
+	switch name {
+	case "workflow_run.json":
+		body, err = os.ReadFile("../test_data/workflow_run.json")
+	case "workflow_job.json":
+		body, err = os.ReadFile("../test_data/workflow_job.json")
+	default:
+		t.Fatalf("unknown metric fixture %q", name)
+	}
+	if err != nil {
+		t.Fatalf("Failed to read test data file: %v", err)
+	}
+	return body
+}
+
+func assertCompletedStateUpdate(t *testing.T, entity string, updates []RunState) {
+	t.Helper()
+
+	if len(updates) != 1 {
+		t.Fatalf("expected one %s state update, got %d", entity, len(updates))
+	}
+	if updates[0].Status != statusCompleted || updates[0].Conclusion != testConclusionSuccess {
+		t.Fatalf("expected completed %s state, got %#v", entity, updates[0])
+	}
 }
 
 func TestWorkflowStatusCounter(t *testing.T) {

--- a/src/redis_integration_test.go
+++ b/src/redis_integration_test.go
@@ -151,18 +151,32 @@ func newRedisIntegrationStore(t *testing.T) *RedisStateStore {
 	return store
 }
 
-func newRedisIntegrationTestServer(t *testing.T, store StateStore) *httptest.Server {
+func newRedisIntegrationTestServer(t *testing.T, store *RedisStateStore) *httptest.Server {
+	t.Helper()
+	return newRedisIntegrationTestServerWithStateBackends(t, store, store, store)
+}
+
+func newRedisIntegrationTestServerWithStateBackends(
+	t *testing.T,
+	deliveryStore deliveryStateBackend,
+	workflowRunStore workflowRunStateBackend,
+	workflowJobStore workflowJobStateBackend,
+) *httptest.Server {
 	t.Helper()
 	resetIntegrationTestMetrics()
 
 	githubWebhookSecret = []byte("integration-test-secret")
-	stateStore = store
+	deliveryStateStore = deliveryStore
+	workflowRunStateStore = workflowRunStore
+	workflowJobStateStore = workflowJobStore
 	eventProcessor = newAsyncEventProcessor(asyncProcessorConfig{WorkerCount: 1, QueueSize: 8}, zap.NewNop())
 	eventProcessor.Start()
 	t.Cleanup(func() {
 		eventProcessor.Stop()
 		eventProcessor = nil
-		stateStore = nil
+		deliveryStateStore = nil
+		workflowRunStateStore = nil
+		workflowJobStateStore = nil
 	})
 
 	router := setupRouter(zap.NewNop(), defaultServiceMetrics, prometheus.DefaultGatherer)

--- a/src/run_transition.go
+++ b/src/run_transition.go
@@ -16,11 +16,6 @@ type runMetricDetails struct {
 	endedAt    string
 }
 
-type runStoreMethods struct {
-	get    func(context.Context, int) (RunState, bool, error)
-	update func(context.Context, int, RunState) error
-}
-
 type runTransitionStore interface {
 	GetRunState(context.Context, int) (RunState, bool, error)
 	UpdateRunState(context.Context, int, RunState) error
@@ -136,16 +131,28 @@ func runDurationSeconds(state RunState) (float64, bool) {
 	return endedAt.Sub(startedAt).Seconds(), true
 }
 
-type runStoreAdapter struct {
-	methods runStoreMethods
+type workflowRunStateAdapter struct {
+	store workflowRunStateBackend
 }
 
-func (a runStoreAdapter) GetRunState(ctx context.Context, id int) (RunState, bool, error) {
-	return a.methods.get(ctx, id)
+func (a workflowRunStateAdapter) GetRunState(ctx context.Context, id int) (RunState, bool, error) {
+	return a.store.GetWorkflowRun(ctx, id)
 }
 
-func (a runStoreAdapter) UpdateRunState(ctx context.Context, id int, state RunState) error {
-	return a.methods.update(ctx, id, state)
+func (a workflowRunStateAdapter) UpdateRunState(ctx context.Context, id int, state RunState) error {
+	return a.store.UpdateWorkflowRun(ctx, id, state)
+}
+
+type workflowJobStateAdapter struct {
+	store workflowJobStateBackend
+}
+
+func (a workflowJobStateAdapter) GetRunState(ctx context.Context, id int) (RunState, bool, error) {
+	return a.store.GetWorkflowJob(ctx, id)
+}
+
+func (a workflowJobStateAdapter) UpdateRunState(ctx context.Context, id int, state RunState) error {
+	return a.store.UpdateWorkflowJob(ctx, id, state)
 }
 
 type metricRunTransitionRecorder struct {

--- a/src/state_store.go
+++ b/src/state_store.go
@@ -2,11 +2,16 @@ package main
 
 import "context"
 
-type StateStore interface {
+type deliveryStateBackend interface {
 	MarkDeliveryProcessed(ctx context.Context, deliveryID string) (bool, error)
+}
+
+type workflowRunStateBackend interface {
 	GetWorkflowRun(ctx context.Context, runID int) (RunState, bool, error)
 	UpdateWorkflowRun(ctx context.Context, runID int, state RunState) error
+}
+
+type workflowJobStateBackend interface {
 	GetWorkflowJob(ctx context.Context, jobID int) (RunState, bool, error)
 	UpdateWorkflowJob(ctx context.Context, jobID int, state RunState) error
-	Close() error
 }

--- a/src/test_support_test.go
+++ b/src/test_support_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "context"
+import (
+	"context"
+	"testing"
+)
 
 const testConclusionSuccess = "success"
 
@@ -16,6 +19,34 @@ func newInMemoryStateStore() *inMemoryStateStore {
 		workflow:   map[int]RunState{},
 		jobs:       map[int]RunState{},
 	}
+}
+
+func useInMemoryStateBackends(t *testing.T) {
+	t.Helper()
+
+	store := newInMemoryStateStore()
+	useStateBackends(t, store, store, store)
+}
+
+func useStateBackends(
+	t *testing.T,
+	deliveryStore deliveryStateBackend,
+	workflowRunStore workflowRunStateBackend,
+	workflowJobStore workflowJobStateBackend,
+) {
+	t.Helper()
+
+	oldDeliveryStore := deliveryStateStore
+	oldWorkflowRunStore := workflowRunStateStore
+	oldWorkflowJobStore := workflowJobStateStore
+	deliveryStateStore = deliveryStore
+	workflowRunStateStore = workflowRunStore
+	workflowJobStateStore = workflowJobStore
+	t.Cleanup(func() {
+		deliveryStateStore = oldDeliveryStore
+		workflowRunStateStore = oldWorkflowRunStore
+		workflowJobStateStore = oldWorkflowJobStore
+	})
 }
 
 func (s *inMemoryStateStore) MarkDeliveryProcessed(_ context.Context, deliveryID string) (bool, error) {

--- a/src/webhook_ingestion.go
+++ b/src/webhook_ingestion.go
@@ -64,7 +64,7 @@ func newDefaultWebhookIngestion() *webhookIngestion {
 	ingestion := &webhookIngestion{
 		secret:        githubWebhookSecret,
 		logger:        logger,
-		deliveryStore: stateStore,
+		deliveryStore: deliveryStateStore,
 		localDeduper:  deliveryDeduperCache,
 		dispatcher:    defaultWebhookEventDispatcher{},
 		metrics:       defaultMetricRecorder,

--- a/src/webhook_ingestion_test.go
+++ b/src/webhook_ingestion_test.go
@@ -171,23 +171,15 @@ func TestWebhookIngestionEnqueuesAcceptedEvent(t *testing.T) {
 }
 
 func TestDefaultWebhookIngestionUsesDeliveryStateWithoutRunState(t *testing.T) {
-	oldDeliveryStore := deliveryStateStore
-	oldWorkflowRunStore := workflowRunStateStore
-	oldWorkflowJobStore := workflowJobStateStore
 	oldProcessor := eventProcessor
 	oldSecret := githubWebhookSecret
 	t.Cleanup(func() {
-		deliveryStateStore = oldDeliveryStore
-		workflowRunStateStore = oldWorkflowRunStore
-		workflowJobStateStore = oldWorkflowJobStore
 		eventProcessor = oldProcessor
 		githubWebhookSecret = oldSecret
 	})
 
 	delivery := &fakeDeliveryMarker{created: true}
-	deliveryStateStore = delivery
-	workflowRunStateStore = nil
-	workflowJobStateStore = nil
+	useStateBackends(t, delivery, nil, nil)
 	eventProcessor = nil
 	githubWebhookSecret = []byte("test-secret")
 

--- a/src/webhook_ingestion_test.go
+++ b/src/webhook_ingestion_test.go
@@ -170,6 +170,38 @@ func TestWebhookIngestionEnqueuesAcceptedEvent(t *testing.T) {
 	}
 }
 
+func TestDefaultWebhookIngestionUsesDeliveryStateWithoutRunState(t *testing.T) {
+	oldDeliveryStore := deliveryStateStore
+	oldWorkflowRunStore := workflowRunStateStore
+	oldWorkflowJobStore := workflowJobStateStore
+	oldProcessor := eventProcessor
+	oldSecret := githubWebhookSecret
+	t.Cleanup(func() {
+		deliveryStateStore = oldDeliveryStore
+		workflowRunStateStore = oldWorkflowRunStore
+		workflowJobStateStore = oldWorkflowJobStore
+		eventProcessor = oldProcessor
+		githubWebhookSecret = oldSecret
+	})
+
+	delivery := &fakeDeliveryMarker{created: true}
+	deliveryStateStore = delivery
+	workflowRunStateStore = nil
+	workflowJobStateStore = nil
+	eventProcessor = nil
+	githubWebhookSecret = []byte("test-secret")
+
+	ingestion := newDefaultWebhookIngestion()
+	result := ingestion.Accept(context.Background(), signedWorkflowRunWebhookRequest([]byte(`{"ok":true}`)))
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, result.StatusCode)
+	}
+	if len(delivery.calls) != 1 || delivery.calls[0] != "delivery-1" {
+		t.Fatalf("expected delivery state to record delivery-1, got %#v", delivery.calls)
+	}
+}
+
 func TestWebhookIngestionReturnsUnavailableWhenQueueIsFull(t *testing.T) {
 	ingestion, _, dispatcher, _ := newTestWebhookIngestion()
 	ingestion.queue = &fakeWebhookQueue{err: errors.New("queue full")}


### PR DESCRIPTION
## Summary
- split production state consumption into delivery, workflow-run, and workflow-job interfaces
- wire webhook ingestion to delivery state only and run transitions to their specific run-state backends
- keep Redis as the shared concrete persistence adapter while avoiding a combined production `StateStore` interface

## TDD notes
- RED: added interface-level coverage showing default webhook ingestion can use delivery state without run state
- RED: added workflow run/job metric tests proving run transitions can use their own state interfaces without delivery state or the other run state
- GREEN/REFACTOR: introduced narrow state backends, adapted run transitions, and updated integration helpers to pass state dependencies independently

## Cardinality guardrails
- no Prometheus collector definitions in `src/metrics.go` were changed
- metric recorder cardinality guard tests remain in place

## Verification
- `make test-all`
- `make lint`
- `make security`

## Author

- Codex (gpt-5.5)
