### PR TITLE
Design layered CI test lanes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,28 +16,19 @@ permissions:
   security-events: write
 
 jobs:
-  unit-and-build:
-    name: build and test
+  fast-pr-lane:
+    name: Fast PR lane
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup environment
-        id: environment
-        run: |
-          echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
-          echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
       - name: Set up Golang
         uses: actions/setup-go@v5
         id: go
         with:
           go-version-file: .go-version
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Install Tools and Dependencies
         run: make install_tools
@@ -54,37 +45,14 @@ jobs:
       - name: Unit Tests
         run: make unit-test
 
+      - name: In-process Integration Tests
+        run: make integration-test
+
       - name: Coverage
         run: make coverage
 
-      - name: Build Container
-        run: make container
-
-      - name: Container Security Scan
-        run: make container-security
-
-  integration-tests:
-    name: Integration tests
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Golang
-        uses: actions/setup-go@v5
-        id: go
-        with:
-          go-version-file: .go-version
-
-      - name: Install Tools and Dependencies
-        run: make deps
-
-      - name: Integration Tests
-        run: make integration-test
-
-  redis-integration-tests:
-    name: Redis integration tests
+  medium-redis-lane:
+    name: Medium Redis lane
     runs-on: ubuntu-24.04
 
     services:
@@ -118,3 +86,36 @@ jobs:
 
       - name: Redis Integration Tests
         run: make redis-integration-test
+
+  deep-container-lane:
+    name: Deep container lane
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        id: environment
+        run: |
+          echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
+          echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
+
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        id: go
+        with:
+          go-version-file: .go-version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install Tools and Dependencies
+        run: make install_tools
+
+      - name: Build Container
+        run: make container
+
+      - name: Container Security Scan
+        run: make container-security

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,5 @@
 # Contributing to `promgithub`
 
-**TODO**
+## Testing
+
+See [Testing and CI lanes](./testing.md) for the CI lane strategy and local verification commands.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,39 @@
+# Testing and CI lanes
+
+`promgithub` uses layered test execution so pull requests get useful feedback quickly while slower checks still run before release-sensitive changes age too long.
+
+## CI lanes
+
+| Lane | CI job | Runs on | Purpose | Local command |
+| --- | --- | --- | --- | --- |
+| Fast PR lane | `Fast PR lane` | Pull requests, pushes to `main`, weekly schedule | Static checks, security scan, build, unit tests, in-process HTTP integration tests, and coverage. This lane has no external service dependency. | `make lint`, `make security`, `make build`, `make unit-test`, `make integration-test`, `make coverage` |
+| Medium Redis lane | `Medium Redis lane` | Pull requests, pushes to `main`, weekly schedule | Redis-backed deduplication and shared run/job state behavior against a real Redis service. | `PROMGITHUB_REDIS_ADDR=127.0.0.1:6379 make redis-integration-test` |
+| Deep container lane | `Deep container lane` | Pushes to `main`, weekly schedule | Container build and container image security scan. This lane is intentionally kept out of normal pull request feedback because it is slower and Docker-dependent. | `make container`, `make container-security` |
+
+## Pull request expectations
+
+Every pull request should keep the Fast PR lane and Medium Redis lane green. Those lanes cover:
+
+- Go unit tests.
+- Lint checks.
+- Vulnerability and static security checks.
+- In-process HTTP webhook-to-metrics behavior.
+- Redis-backed delivery deduplication and run/job state behavior.
+
+The Deep container lane runs after merge to `main` and on the weekly scheduled workflow. It catches packaging and image-scan issues without making every pull request wait on Docker image work.
+
+## Local verification
+
+Before committing changes, run:
+
+```bash
+make test-all
+make lint
+make security
+```
+
+`make test-all` already includes the unit, integration, Redis integration, coverage, security, and lint targets. Run `make lint` and `make security` separately as explicit final checks before pushing.
+
+## Future system smoke tests
+
+Black-box container and Helm/deployment smoke tests are tracked separately in issue #56. When those tests exist, they should join the Deep container lane or a dedicated deep system lane rather than the Fast PR lane.


### PR DESCRIPTION
## Summary
- split the build workflow into explicit Fast PR, Medium Redis, and Deep container lanes
- keep in-process integration coverage in the fast PR path and Redis-backed coverage in its own service-backed lane
- move container build/security scanning out of normal pull request feedback and into push/scheduled runs
- document the lane contract and local execution commands in `docs/testing.md`

## Issue
Closes #57

## Verification
- `make test-all`
- `make lint`
- `make security`
