### PR TITLE
Align Helm Redis dependency with Chart.lock

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -10,12 +10,12 @@ source ./version
 # Update chart version
 if sed --version > /dev/null; then
     # Using GNU sed (Linux)
-    sed -i "s/version: .*/version: $VERSION/" helm/promgithub/Chart.yaml
-    sed -i "s/appVersion: .*/appVersion: \"$VERSION\"/" helm/promgithub/Chart.yaml
+    sed -i "s/^version: .*/version: $VERSION/" helm/promgithub/Chart.yaml
+    sed -i "s/^appVersion: .*/appVersion: \"$VERSION\"/" helm/promgithub/Chart.yaml
 else
     # Using BSD sed (macOS)
-    sed -i '' "s/version: .*/version: $VERSION/" helm/promgithub/Chart.yaml
-    sed -i '' "s/appVersion: .*/appVersion: \"$VERSION\"/" helm/promgithub/Chart.yaml
+    sed -i '' "s/^version: .*/version: $VERSION/" helm/promgithub/Chart.yaml
+    sed -i '' "s/^appVersion: .*/appVersion: \"$VERSION\"/" helm/promgithub/Chart.yaml
 fi
 
 # Run go fmt to format the source code

--- a/helm/promgithub/Chart.yaml
+++ b/helm/promgithub/Chart.yaml
@@ -13,6 +13,6 @@ appVersion: "0.0.7"
 
 dependencies:
   - name: redis
-    version: 0.0.7
+    version: 23.1.1
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.enabled


### PR DESCRIPTION
## Summary
- The deep container lane on `8f0802d` (`#70` merge) failed in Helm Deployment Smoke Test: `Chart.lock` is out of sync with `Chart.yaml`.
- `Chart.yaml` still listed Bitnami Redis as `0.0.7` (copied from the app/chart version). `Chart.lock` already had the real chart, `23.1.1`.
- This updates the Chart.yaml pin so `helm dependency build` succeeds. Verified locally with `helm dependency build`, `helm lint`, and `helm template` (the steps that failed before kind).

## Test plan
- [ ] Fast PR lane and Medium Redis lane stay green
- [ ] After merge, Deep container and system lane gets past Helm Deployment Smoke Test
- [ ] Optional: `helm dependency build helm/promgithub && helm lint helm/promgithub`


Made with [Cursor](https://cursor.com)